### PR TITLE
Update Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -70,19 +70,19 @@ Returns a new combined stream object. Available options are:
 
 The effect of those options is described below.
 
-### combinedStream.pauseStreams = true
+### combinedStream.pauseStreams = `true`
 
 Whether to apply back pressure to the underlaying streams. If set to `false`,
 the underlaying streams will never be paused. If set to `true`, the
 underlaying streams will be paused right after being appended, as well as when
 `delayedStream.pipe()` wants to throttle.
 
-### combinedStream.maxDataSize = 2 * 1024 * 1024
+### combinedStream.maxDataSize = `2 * 1024 * 1024`
 
 The maximum amount of bytes (or characters) to buffer for all source streams.
 If this value is exceeded, `combinedStream` emits an `'error'` event.
 
-### combinedStream.dataSize = 0
+### combinedStream.dataSize = `0`
 
 The amount of bytes (or characters) currently buffered by `combinedStream`.
 


### PR DESCRIPTION
Quoting javascript stuff

`2 * 1024 * 1024` was appearing as 2 \* 1024 \* 1024 (the `*` was being interpreted as "italic")
