### PR TITLE
Fix the memory leak issue when attaching large streams

### DIFF
--- a/lib/combined_stream.js
+++ b/lib/combined_stream.js
@@ -30,7 +30,7 @@ CombinedStream.create = function(options) {
 CombinedStream.isStreamLike = function(stream) {
   return (typeof stream !== 'function')
     && (typeof stream !== 'string')
-    && (typeof stream !== 'boolean')    
+    && (typeof stream !== 'boolean')
     && (typeof stream !== 'number')
     && (!Buffer.isBuffer(stream));
 };
@@ -97,7 +97,7 @@ CombinedStream.prototype._pipeNext = function(stream) {
 
   var isStreamLike = CombinedStream.isStreamLike(stream);
   if (isStreamLike) {
-    stream.on('end', this._getNext.bind(this))
+    stream.on('end', this._getNext.bind(this));
     stream.pipe(this, {end: false});
     return;
   }
@@ -123,16 +123,23 @@ CombinedStream.prototype.pause = function() {
     return;
   }
 
+  this.writable = false;
+  if(this._currentStream.pause) {
+    this._currentStream.pause();
+  }
   this.emit('pause');
 };
 
 CombinedStream.prototype.resume = function() {
   if (!this._released) {
     this._released = true;
-    this.writable = true;
     this._getNext();
   }
 
+  this.writable = true;
+  if(this._currentStream.resume) {
+    this._currentStream.resume();
+  }
   this.emit('resume');
 };
 

--- a/lib/combined_stream.js
+++ b/lib/combined_stream.js
@@ -124,7 +124,7 @@ CombinedStream.prototype.pause = function() {
   }
 
   this.writable = false;
-  if(this._currentStream.pause) {
+  if(typeof(this._currentStream.pause) == 'function') {
     this._currentStream.pause();
   }
   this.emit('pause');
@@ -137,7 +137,7 @@ CombinedStream.prototype.resume = function() {
   }
 
   this.writable = true;
-  if(this._currentStream.resume) {
+  if(typeof(this._currentStream.resume) == 'function') {
     this._currentStream.resume();
   }
   this.emit('resume');
@@ -166,7 +166,7 @@ CombinedStream.prototype._checkDataSize = function() {
   }
 
   var message =
-    'DelayedStream#maxDataSize of ' + this.maxDataSize + ' bytes exceeded.'
+    'DelayedStream#maxDataSize of ' + this.maxDataSize + ' bytes exceeded.';
   this._emitError(new Error(message));
 };
 

--- a/lib/combined_stream.js
+++ b/lib/combined_stream.js
@@ -123,7 +123,7 @@ CombinedStream.prototype.pause = function() {
     return;
   }
 
-  if(typeof(this._currentStream.pause) == 'function') this._currentStream.pause();
+  if(this.pauseStreams && typeof(this._currentStream.pause) == 'function') this._currentStream.pause();
   this.emit('pause');
 };
 
@@ -134,7 +134,7 @@ CombinedStream.prototype.resume = function() {
     this._getNext();
   }
 
-  if(typeof(this._currentStream.resume) == 'function') this._currentStream.resume();
+  if(this.pauseStreams && typeof(this._currentStream.resume) == 'function') this._currentStream.resume();
   this.emit('resume');
 };
 

--- a/lib/combined_stream.js
+++ b/lib/combined_stream.js
@@ -131,8 +131,8 @@ CombinedStream.prototype.pause = function() {
 
 CombinedStream.prototype.resume = function() {
   if (!this._released) {
-    this.writable = true;
     this._released = true;
+    this.writable = true;
     this._getNext();
   }
 

--- a/lib/combined_stream.js
+++ b/lib/combined_stream.js
@@ -123,9 +123,7 @@ CombinedStream.prototype.pause = function() {
     return;
   }
 
-  if(typeof(this._currentStream.pause) == 'function') {
-    this._currentStream.pause();
-  }
+  if(typeof(this._currentStream.pause) == 'function') this._currentStream.pause();
   this.emit('pause');
 };
 
@@ -136,9 +134,7 @@ CombinedStream.prototype.resume = function() {
     this._getNext();
   }
 
-  if(typeof(this._currentStream.resume) == 'function') {
-    this._currentStream.resume();
-  }
+  if(typeof(this._currentStream.resume) == 'function') this._currentStream.resume();
   this.emit('resume');
 };
 

--- a/lib/combined_stream.js
+++ b/lib/combined_stream.js
@@ -123,7 +123,6 @@ CombinedStream.prototype.pause = function() {
     return;
   }
 
-  this.writable = false;
   if(typeof(this._currentStream.pause) == 'function') {
     this._currentStream.pause();
   }
@@ -132,11 +131,11 @@ CombinedStream.prototype.pause = function() {
 
 CombinedStream.prototype.resume = function() {
   if (!this._released) {
+    this.writable = true;
     this._released = true;
     this._getNext();
   }
 
-  this.writable = true;
   if(typeof(this._currentStream.resume) == 'function') {
     this._currentStream.resume();
   }


### PR DESCRIPTION
See mikeal/request#898

When attaching a large file (or any other readable stream), and the write stream is much slower than the read stream , it will make the entire content of the file to be loaded into memory, which causes huge memory leak (In my case it consumes more than 600M rss and created more than 20,000 Buffer objects which cannot be GCed when attaching a 600M file stream and pipe it to request upload.)

I've added couple of lines to make sure when it's paused, it should not be writable, it seems fixed the problem.