### PR TITLE
Allow append callbacks to fail silently.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -49,11 +49,24 @@ var CombinedStream = require('combined-stream');
 var fs = require('fs');
 
 var combinedStream = CombinedStream.create();
+
 combinedStream.append(function(next) {
   next(fs.createReadStream('file1.txt'));
 });
+
 combinedStream.append(function(next) {
-  next(fs.createReadStream('file2.txt'));
+  fs.stat('file2.txt', function(err, stats) {
+    if (err || !stats.isFile()){
+      // don't append a stream:
+      next();
+    } else {
+      next(fs.createReadStream('file2.txt'));
+    }
+  });
+});
+
+combinedStream.append(function(next) {
+  next(fs.createReadStream('file3.txt'));
 });
 
 combinedStream.pipe(fs.createWriteStream('combined.txt'));

--- a/lib/combined_stream.js
+++ b/lib/combined_stream.js
@@ -29,14 +29,21 @@ CombinedStream.create = function(options) {
 
 CombinedStream.isStreamLike = function(stream) {
   return (typeof stream !== 'function')
-    && (typeof stream !== 'string')
-    && (typeof stream !== 'boolean')    
-    && (typeof stream !== 'number')
-    && (!Buffer.isBuffer(stream));
+    && (typeof stream === 'object')
+    && (stream !== null)
+    // the functions we use:
+    && (typeof stream.on === 'function')
+    && (typeof stream.pause === 'function')
+    && (typeof stream.resume === 'function')
+    && (typeof stream.emit === 'function');
 };
 
 CombinedStream.prototype.append = function(stream) {
   var isStreamLike = CombinedStream.isStreamLike(stream);
+
+  if (arguments.length === 0) {
+    return this;
+  }
 
   if (isStreamLike) {
     if (!(stream instanceof DelayedStream)) {
@@ -67,14 +74,12 @@ CombinedStream.prototype.pipe = function(dest, options) {
 
 CombinedStream.prototype._getNext = function() {
   this._currentStream = null;
-  var stream = this._streams.shift();
-
-
-  if (typeof stream == 'undefined') {
+  if (this._streams.length === 0) {
     this.end();
     return;
   }
 
+  var stream = this._streams.shift();
   if (typeof stream !== 'function') {
     this._pipeNext(stream);
     return;
@@ -82,13 +87,16 @@ CombinedStream.prototype._getNext = function() {
 
   var getStream = stream;
   getStream(function(stream) {
-    var isStreamLike = CombinedStream.isStreamLike(stream);
-    if (isStreamLike) {
-      stream.on('data', this._checkDataSize.bind(this));
-      this._handleErrors(stream);
+    if(arguments.length > 0){
+      var isStreamLike = CombinedStream.isStreamLike(stream);
+      if (isStreamLike) {
+        stream.on('data', this._checkDataSize.bind(this));
+        this._handleErrors(stream);
+      }
+      this._pipeNext(stream);
+    } else {
+      this._getNext();
     }
-
-    this._pipeNext(stream);
   }.bind(this));
 };
 
@@ -168,11 +176,9 @@ CombinedStream.prototype._updateDataSize = function() {
 
   var self = this;
   this._streams.forEach(function(stream) {
-    if (!stream.dataSize) {
-      return;
+    if (stream && 'dataSize' in stream) {
+      self.dataSize += stream.dataSize;
     }
-
-    self.dataSize += stream.dataSize;
   });
 
   if (this._currentStream && this._currentStream.dataSize) {

--- a/test/common.js
+++ b/test/common.js
@@ -2,6 +2,8 @@ var common = module.exports;
 
 var path = require('path');
 var fs = require('fs');
+var util = require('util');
+var Stream = require('stream').Stream;
 var root = path.join(__dirname, '..');
 
 common.dir = {
@@ -21,3 +23,28 @@ catch (e) {
 
 common.CombinedStream = require(root);
 common.assert = require('assert');
+
+
+function RecorderStream() {
+  if (!(this instanceof RecorderStream)) {
+    return new RecorderStream();
+  }
+  this.writable = true;
+  this.data = [];
+}
+util.inherits(RecorderStream,Stream);
+
+RecorderStream.prototype.write = function(chunk,encoding) {
+  this.data.push(chunk);
+  this.emit('data',chunk);
+}
+
+RecorderStream.prototype.end = function(chunk,encoding) {
+  this.emit('end');
+}
+
+RecorderStream.prototype.toString = function(){
+  return this.data;
+}
+
+common.RecorderStream = RecorderStream;

--- a/test/integration/test-is-stream-like.js
+++ b/test/integration/test-is-stream-like.js
@@ -12,6 +12,12 @@ var foo = function(){};
   assert(! CombinedStream.isStreamLike("I am a string"));
   assert(! CombinedStream.isStreamLike(7));
   assert(! CombinedStream.isStreamLike(foo));
+  assert(! CombinedStream.isStreamLike(undefined));
+  assert(! CombinedStream.isStreamLike(null));
+  assert(! CombinedStream.isStreamLike({}));
+  assert(! CombinedStream.isStreamLike([]));
+  assert(! CombinedStream.isStreamLike([42, foo]));
+  assert(! CombinedStream.isStreamLike({ on: function(){} }));
 
   assert(CombinedStream.isStreamLike(fileStream));
 })();

--- a/test/integration/test-no-streams.js
+++ b/test/integration/test-no-streams.js
@@ -1,0 +1,44 @@
+var common = require('../common');
+var assert = common.assert;
+var CombinedStream = common.CombinedStream;
+
+var s
+var recorder;
+
+var EXPECTED = [];
+
+// no append calls
+s = CombinedStream.create();
+recorder = new common.RecorderStream();
+s.pipe(recorder);
+s.resume();
+assert.deepEqual(recorder.data, EXPECTED);
+
+s.pipe(recorder);
+s.resume();
+assert.deepEqual(recorder.data, EXPECTED);
+
+// append call w/o arguments
+s = CombinedStream.create();
+recorder = new common.RecorderStream();
+s.append();
+s.pipe(recorder);
+s.resume();
+assert.deepEqual(recorder.data, EXPECTED);
+
+s.pipe(recorder);
+s.resume();
+assert.deepEqual(recorder.data, EXPECTED);
+
+// failed append call
+s = CombinedStream.create();
+recorder = new common.RecorderStream();
+s.append(function(next) {
+  // don't append a stream:
+  next();
+});
+
+s.pipe(recorder);
+s.resume();
+assert.deepEqual(recorder.data, EXPECTED);
+

--- a/test/integration/test-undefined-and-null.js
+++ b/test/integration/test-undefined-and-null.js
@@ -1,0 +1,40 @@
+var common = require('../common');
+var assert = common.assert;
+var CombinedStream = common.CombinedStream;
+
+var s = CombinedStream.create();
+var recorder = new common.RecorderStream();
+
+var EXPECTED = [
+  'foo',
+  undefined,
+  3,
+  null,
+  { bar: 'bar' }
+];
+
+EXPECTED.forEach(s.append, s);
+
+EXPECTED.push(undefined);
+s.append(function(done) {
+  done(undefined);
+});
+
+s.append(function(done) {
+  // don't append anything
+  done();
+});
+
+EXPECTED.push('foobar');
+s.append(function(done) {
+  done('foobar');
+});
+
+EXPECTED.push(null);
+s.append(function(done) {
+  done(null);
+});
+
+s.pipe(recorder);
+s.resume();
+assert.deepEqual(recorder.data, EXPECTED);


### PR DESCRIPTION
First thank you for this great module. :+1: 

**This PR allow one to do the following:**

```Javascript
combinedStream.append(function(next) {
  fs.stat('file2.txt', function(err, stats) {
    if (err || !stats.isFile()){
      // don't append a stream:
      next();
    } else {
      next(fs.createReadStream('file2.txt'));
    }
  });
});
```

**It also includes an enhanced "`undefined` and `null` as streams" treatment:**
```Javascript
combinedStream.append('foo');     // emits 'foo' (as usual)
combinedStream.append(null);      // emits null
combinedStream.append(undefined); // emits undefined

combinedStream.append(function(next) {
  next(undefined); // emits undefined (!) 
});

combinedStream.append(function(next) {
  next(); // don't emits undefined (!) 
});

combinedStream.append(function(next) {
  next(null); // emits null
});
```