### PR TITLE
compatibility with `new` and standard class inheritance

### DIFF
--- a/lib/combined_stream.js
+++ b/lib/combined_stream.js
@@ -3,7 +3,7 @@ var Stream = require('stream').Stream;
 var DelayedStream = require('delayed-stream');
 
 module.exports = CombinedStream;
-function CombinedStream() {
+function CombinedStream(options) {
   this.writable = false;
   this.readable = true;
   this.dataSize = 0;
@@ -13,17 +13,16 @@ function CombinedStream() {
   this._released = false;
   this._streams = [];
   this._currentStream = null;
+
+  options = options || {};
+  for (var option in options) {
+    this[option] = options[option];
+  }
 }
 util.inherits(CombinedStream, Stream);
 
 CombinedStream.create = function(options) {
-  var combinedStream = new this();
-
-  options = options || {};
-  for (var option in options) {
-    combinedStream[option] = options[option];
-  }
-
+  var combinedStream = new this(options);
   return combinedStream;
 };
 


### PR DESCRIPTION
Moves setting options into the constructor, so that options are still set when calling `new` or when class is extended.