### PR TITLE
Prevent data loss when input stream has already finished writing

### DIFF
--- a/lib/combined_stream.js
+++ b/lib/combined_stream.js
@@ -40,12 +40,12 @@ CombinedStream.prototype.append = function(stream) {
 
   if (isStreamLike) {
     if (!(stream instanceof DelayedStream)) {
-      stream.on('data', this._checkDataSize.bind(this));
-
-      stream = DelayedStream.create(stream, {
+      var newStream = DelayedStream.create(stream, {
         maxDataSize: Infinity,
         pauseStream: this.pauseStreams,
       });
+      stream.on('data', this._checkDataSize.bind(this));
+      stream = newStream;
     }
 
     this._handleErrors(stream);


### PR DESCRIPTION
This closes #15.

The bug happens when the input stream has already finished writing, which causes the `data` event to fire before the `DelayedStream` gets created.
