### PR TITLE
Added startWaiting / stopWaiting support 

### DIFF
--- a/lib/combined_stream.js
+++ b/lib/combined_stream.js
@@ -13,6 +13,7 @@ function CombinedStream() {
   this._released = false;
   this._streams = [];
   this._currentStream = null;
+  this._waitForIt = false;
 }
 util.inherits(CombinedStream, Stream);
 
@@ -56,6 +57,9 @@ CombinedStream.prototype.append = function(stream) {
   }
 
   this._streams.push(stream);
+  if (this._released && !this._currentStream) {
+    this._getNext()
+  }
   return this;
 };
 
@@ -65,13 +69,26 @@ CombinedStream.prototype.pipe = function(dest, options) {
   return dest;
 };
 
+CombinedStream.prototype.startWaiting = function() {
+  this._waitForIt = true
+}
+
+CombinedStream.prototype.stopWaiting = function() {
+  this._waitForIt = false
+  if (this._streams.length === 0) {
+    this.end();
+  }
+};
+
 CombinedStream.prototype._getNext = function() {
   this._currentStream = null;
   var stream = this._streams.shift();
 
 
   if (typeof stream == 'undefined') {
-    this.end();
+    if (!this._waitForIt) {
+      this.end();
+    }
     return;
   }
 


### PR DESCRIPTION
This PR adds support of waiting to combined-stream. With `startWaiting` `stopWaiting` you can modify the end-of-queue behaviour in that if the end is reached it will not `end` the stream rather keep it open until `stopWaiting` is reached. 