### PR TITLE
Add option for controlling if the combinedStream automatically ends

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -73,6 +73,7 @@ Returns a new combined stream object. Available options are:
 
 * `maxDataSize`
 * `pauseStreams`
+* `autoEnd`
 
 The effect of those options is described below.
 
@@ -87,6 +88,13 @@ underlaying streams will be paused right after being appended, as well as when
 
 The maximum amount of bytes (or characters) to buffer for all source streams.
 If this value is exceeded, `combinedStream` emits an `'error'` event.
+
+### combinedStream.autoEnd = `true`
+
+If set to `true`, automatically ends the stream by calling 
+`combinedStream.end()` when the last stream emits `'end'`.
+If set to `false`, `combinedStream.end()` must be manually called to end the 
+stream.
 
 ### combinedStream.dataSize = `0`
 

--- a/lib/combined_stream.js
+++ b/lib/combined_stream.js
@@ -9,6 +9,7 @@ function CombinedStream() {
   this.dataSize = 0;
   this.maxDataSize = 2 * 1024 * 1024;
   this.pauseStreams = true;
+  this.autoEnd = true;
 
   this._released = false;
   this._streams = [];
@@ -58,6 +59,9 @@ CombinedStream.prototype.append = function(stream) {
   }
 
   this._streams.push(stream);
+  if(!this.autoEnd && !this._currentStream && this._streams.length === 1) {
+    this._getNext();
+  }
   return this;
 };
 
@@ -91,7 +95,9 @@ CombinedStream.prototype._realGetNext = function() {
 
 
   if (typeof stream == 'undefined') {
-    this.end();
+    if(this.autoEnd) {
+      this.end();
+    }
     return;
   }
 

--- a/test/integration/test-auto-end.js
+++ b/test/integration/test-auto-end.js
@@ -1,0 +1,46 @@
+var common = require('../common');
+var assert = common.assert;
+var CombinedStream = common.CombinedStream;
+var fs = require('fs');
+
+var FILE1 = common.dir.fixture + '/file1.txt';
+var FILE2 = common.dir.fixture + '/file2.txt';
+var EXPECTED = fs.readFileSync(FILE1) + fs.readFileSync(FILE2);
+
+(function testAutoEnd() {
+  var combinedStream = CombinedStream.create({autoEnd: false});
+  var stream = fs.createReadStream(FILE1);
+  combinedStream.append(stream);
+
+  var ended = false;
+  combinedStream.on('end', function() {
+    ended = true;
+  });
+
+  stream.on('end', () => {
+    setImmediate(() => {
+        assert.ok(!ended);
+
+        var stream2 = fs.createReadStream(FILE2);
+        stream2.on('end', () => {
+          assert.ok(!ended);
+
+          combinedStream.end();
+        });
+        combinedStream.append(stream2);
+    });
+  });
+
+  var tmpFile = common.dir.tmp + '/combined.txt';
+  var dest = fs.createWriteStream(tmpFile);
+  combinedStream.pipe(dest);
+
+  dest.on('end', function() {
+    var written = fs.readFileSync(tmpFile, 'utf8');
+    assert.strictEqual(written, EXPECTED);
+  });
+
+  process.on('exit', () => {
+    assert.ok(ended);
+  });
+})();


### PR DESCRIPTION
Adds an autoEnd option to disable the current behavior of the CombinedStream automatically ending when the stream queue is empty.
By default this has no changes to the existing behavior (autoEnd = true).
The use case I am trying to solve is when the streams are not known ahead of time and are dynamically generated. 
This option is similar to the 'end' option on stream.Readable.pipe().
This is similar in nature to https://github.com/felixge/node-combined-stream/pull/31