### PR TITLE
fix issue with bun not detecting exported module during install

### DIFF
--- a/lib/combined_stream.js
+++ b/lib/combined_stream.js
@@ -2,7 +2,6 @@ var util = require('util');
 var Stream = require('stream').Stream;
 var DelayedStream = require('delayed-stream');
 
-module.exports = CombinedStream;
 function CombinedStream() {
   this.writable = false;
   this.readable = true;
@@ -206,3 +205,6 @@ CombinedStream.prototype._emitError = function(err) {
   this._reset();
   this.emit('error', err);
 };
+
+module.exports = CombinedStream;
+


### PR DESCRIPTION
I recently came across an error while using bun to install this package through the form-data package:

error: Cannot find package "combined-stream" from "/usr/src/app/node_modules/form-data/lib/form_data.js"

The following patch fixed the issue.